### PR TITLE
nginx, main app server block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,48 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$IP = "192.168.9.17"
+$MEM = "1024"
+
+# set up our provisioning scripts as ruby variables
+$always = <<ALWAYS
+cat > /etc/nginx/sites-enabled/site <<'EOL'
+    server {
+        listen 80;
+        server_name tskr.dev;
+        root /var/www/app;
+        index index.html index.htm;
+
+        try_files $uri $uri/ /index.html =404;
+    }
+EOL
+
+    # restart nginx
+    service nginx restart
+
+ALWAYS
+
+$once = <<ONCE
+
+    # update and upgrade
+    apt-get update
+    # apt-get upgrade -y
+
+    # install nginx
+    apt-get install -y nginx
+
+    # nginx tweaks - sendfile off, remove default server block
+    sed -i "s/sendfile on/sendfile off/g" /etc/nginx/nginx.conf
+    rm /etc/nginx/sites-enabled/default
+ONCE
+
+Vagrant.configure(2) do |config|
+    config.vm.box = "ubuntu/trusty64"
+    config.vm.network "private_network", ip: $IP
+    config.vm.synced_folder ".", "/var/www"
+    config.vm.provider "virtualbox" do |vb|
+        vb.memory = $MEM
+    end
+    config.vm.provision "once", type: "shell", inline: $once
+    config.vm.provision "always", type: "shell", inline: $always, run: "always" 
+end

--- a/app/index.html
+++ b/app/index.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<script>
+	alert('welcome');
+</script>


### PR DESCRIPTION
I've set up the vagrantfile for local development that provisions an nginx webserver and sets up a server block for the main app, which in this case will serve up only index.html. Everything else will be controlled via our angular app eventually.

I like to set up a 'once' and 'always' provision block, and in this project, because there will be very few server blocks, I can include them directly in the always block. I also set the IP and the memory as variables near the top for easy switching.
