### PR TITLE
add cdn for assets and server block to emulate actual cdn

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,6 +15,15 @@ cat > /etc/nginx/sites-enabled/site <<'EOL'
 
         try_files $uri $uri/ /index.html =404;
     }
+
+    server {
+        listen 80;
+        server_name cdn.tskr.dev;
+        root /var/www/cdn;
+        index index.html index.htm;
+
+        try_files $uri $uri/ /index.html =404;
+    }
 EOL
 
     # restart nginx

--- a/app/index.html
+++ b/app/index.html
@@ -1,4 +1,2 @@
 <!doctype html>
-<script>
-	alert('welcome');
-</script>
+<script src="http://cdn.tskr.dev/js/index.js"></script>

--- a/cdn/js/index.js
+++ b/cdn/js/index.js
@@ -1,0 +1,1 @@
+alert('welcome');


### PR DESCRIPTION
Added a new server block to emulate assets coming from a cdn (cdn.tskr.dev). Eventually, this cdn folder would be synced with something like AWS S3 and used with AWS CloudFront. I like the jspm and bundle approach for js with dynamic loading, but we'll see if I can get that far with this project.
