### PR TITLE
Restructure, Angular Structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .vagrant/
-cdn/js/jspm_packages
+client/jspm_packages

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,7 +39,7 @@ EOL
     service nginx restart
 
     # update jspm packages
-    cd /var/www/client/js && jspm install
+    cd /var/www/client && jspm install
 
 ALWAYS
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,46 +10,10 @@ cat > /etc/nginx/sites-enabled/site <<'EOL'
     server {
         listen 80;
         server_name tskr.dev;
-        root /var/www/app;
+        root /var/www/client;
         index index.html index.htm;
 
         try_files $uri $uri/ /index.html =404;
-    }
-
-    server {
-        listen 80;
-        server_name cdn.tskr.dev;
-        root /var/www/cdn;
-        index index.html index.htm;
-
-        try_files $uri $uri/ /index.html =404;
-
-        # enable CORS
-        location / {
-            if ($request_method = 'OPTIONS') {
-                add_header 'Access-Control-Allow-Origin' '*';
-                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-
-                # Custom headers and headers various browsers *should* be OK with but aren't
-                add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
-
-                # Tell client that this pre-flight info is valid for 20 days
-                add_header 'Access-Control-Max-Age' 1728000;
-                add_header 'Content-Type' 'text/plain charset=UTF-8';
-                add_header 'Content-Length' 0;
-                return 204;
-            }
-            if ($request_method = 'POST') {
-                add_header 'Access-Control-Allow-Origin' '*';
-                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-                add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
-            }
-            if ($request_method = 'GET') {
-                add_header 'Access-Control-Allow-Origin' '*';
-                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-                add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
-            }
-        }
     }
 
     server {
@@ -75,7 +39,7 @@ EOL
     service nginx restart
 
     # update jspm packages
-    cd /var/www/cdn/js && jspm install
+    cd /var/www/client/js && jspm install
 
 ALWAYS
 

--- a/app/index.html
+++ b/app/index.html
@@ -1,6 +1,0 @@
-<!doctype html>
-<script src="http://cdn.tskr.dev/js/jspm_packages/system.js"></script>
-<script src="http://cdn.tskr.dev/js/config.js"></script>
-<script>
-	System.import('index.js');
-</script>

--- a/cdn/js/index.js
+++ b/cdn/js/index.js
@@ -1,1 +1,0 @@
-alert('welcome');

--- a/cdn/js/package.json
+++ b/cdn/js/package.json
@@ -1,9 +1,0 @@
-{
-  "jspm": {
-    "devDependencies": {
-      "babel": "npm:babel-core@^5.8.24",
-      "babel-runtime": "npm:babel-runtime@^5.8.24",
-      "core-js": "npm:core-js@^1.1.4"
-    }
-  }
-}

--- a/client/app.component.js
+++ b/client/app.component.js
@@ -1,0 +1,11 @@
+import template from './app.html!text';
+//import './app.css!';
+
+let appComponent = ()=>{
+	return {
+		template, // because we have a variable name template we can use the shorcut here
+		restrict: 'E'
+	};
+};
+
+export default appComponent;

--- a/client/app.html
+++ b/client/app.html
@@ -1,0 +1,4 @@
+<!--Anything you want to be on every page, place it in this file-->
+<div class="app">
+	<div ui-view>Default View</div>
+</div>

--- a/client/components/components.js
+++ b/client/components/components.js
@@ -1,0 +1,8 @@
+import angular from 'angular';
+import Home from './home/home';
+
+let componentModule = angular.module('app.components', [
+	Home.name
+]);
+
+export default componentModule;

--- a/client/components/home/home.component.js
+++ b/client/components/home/home.component.js
@@ -1,0 +1,16 @@
+import controller from './home.controller';
+import template from './home.html!text';
+import './home.css!';
+
+let homeComponent = function(){
+	return {
+		template,
+		controller,
+		restrict: 'E',
+		controllerAs: 'vm',
+		scope: {},
+		bindToController: true
+	};
+};
+
+export default homeComponent;

--- a/client/components/home/home.controller.js
+++ b/client/components/home/home.controller.js
@@ -1,0 +1,7 @@
+class HomeController {
+	constructor(){
+		this.name = 'home';
+	}
+}
+
+export default HomeController;

--- a/client/components/home/home.html
+++ b/client/components/home/home.html
@@ -1,0 +1,5 @@
+<main>
+	<div>
+		<h1>{{ vm.name }}</h1>
+	</div>
+</main>

--- a/client/components/home/home.js
+++ b/client/components/home/home.js
@@ -1,0 +1,19 @@
+import angular from 'angular';
+import 'angular-ui-router';
+import homeComponent from './home.component';
+
+let homeModule = angular.module('home', [
+	'ui.router'
+])
+.config(($stateProvider, $urlRouterProvider)=>{
+	$urlRouterProvider.otherwise('/');
+	
+	$stateProvider
+		.state('home', {
+			url: '/',
+			template: '<home></home>'
+		});
+})
+.directive('home', homeComponent);
+
+export default homeModule;

--- a/client/config.js
+++ b/client/config.js
@@ -1,5 +1,5 @@
 System.config({
-  baseURL: "http://cdn.tskr.dev/js/",
+  baseURL: "/",
   defaultJSExtensions: true,
   transpiler: "babel",
   babelOptions: {
@@ -14,9 +14,15 @@ System.config({
   },
 
   map: {
+    "angular": "github:angular/bower-angular@1.5.8",
+    "angular-ui-router": "github:angular-ui/angular-ui-router-bower@0.3.1",
     "babel": "npm:babel-core@5.8.38",
     "babel-runtime": "npm:babel-runtime@5.8.38",
     "core-js": "npm:core-js@1.2.7",
+    "text": "github:systemjs/plugin-text@0.0.9",
+    "github:angular-ui/angular-ui-router-bower@0.3.1": {
+      "angular": "github:angular/bower-angular@1.5.8"
+    },
     "github:jspm/nodelibs-assert@0.1.0": {
       "assert": "npm:assert@1.4.1"
     },

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<script src="/jspm_packages/system.js"></script>
+<script src="/config.js"></script>
+<script>
+	System.import('index.js');
+</script>

--- a/client/index.js
+++ b/client/index.js
@@ -1,0 +1,33 @@
+import angular from 'angular';
+import 'angular-ui-router';
+import AppComponent from './app.component';
+//import Components from './components/components';
+
+let appModule = angular.module('app', [
+	'ui.router',
+	//Components.name
+])
+.directive('app', AppComponent);
+
+// manually bootstrap
+var container = document.createElement('div');
+container.id ='app-container';
+var appNode = document.createElement('app');
+container.appendChild(appNode);
+var noAngularDOM = container.cloneNode(true);
+
+document.body.appendChild(container);
+
+angular.element(document).ready(() => {
+	angular.bootstrap(container, [appModule.name]), {
+		strictDi: true
+	}
+});
+
+export default appModule;
+
+export function __unload() {
+	container = document.getElementById('app-container');
+	container.remove();
+	document.body.appendChild(noAngularDOM.cloneNode(true));
+}

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,14 @@
+{
+  "jspm": {
+    "dependencies": {
+      "angular": "github:angular/bower-angular@^1.5.8",
+      "angular-ui-router": "github:angular-ui/angular-ui-router-bower@^0.3.1",
+      "text": "github:systemjs/plugin-text@^0.0.9"
+    },
+    "devDependencies": {
+      "babel": "npm:babel-core@^5.8.24",
+      "babel-runtime": "npm:babel-runtime@^5.8.24",
+      "core-js": "npm:core-js@^1.1.4"
+    }
+  }
+}


### PR DESCRIPTION
With the choice to go with jspm and es6 and do transpiling and bundling, the cdn idea became unnecessary. So the client side (index + js files) became 'client'. It really becomes the dev area as we're transpiling in-browser with jspm and systemjs. Implementing jspm hot reloader is now a progressive enhancement, but I don't know if I'm going to tackle that quite yet. The cdn folder might come back, but probably be called 'stage' or  'dist' as it will hold the transpiled, bundled js distributions.
Also, I'm starting the structure of the angular portion. I'm going with a component-type structure with ES6 syntax, using jspm to manage libraries and systemjs for transpiling. New for me, should be fun.
